### PR TITLE
fix: Fix handling cache path nil value

### DIFF
--- a/lua/jfind/init.lua
+++ b/lua/jfind/init.lua
@@ -3,7 +3,7 @@ local PLUGIN_DIR = vim.fn.fnamemodify(FILE_PATH, ':p:h:h:h')
 local SCRIPTS_DIR = PLUGIN_DIR .. "/scripts"
 local HOME = vim.fn.getenv("HOME")
 local CACHE = vim.fn.getenv("XDG_CACHE_HOME")
-if CACHE == "" then CACHE = HOME .. "/.cache" end
+if CACHE == "" or CACHE == vim.NIL then CACHE = HOME .. "/.cache" end
 
 local JFIND_GITHUB_URL = "https://github.com/jake-stewart/jfind"
 


### PR DESCRIPTION
## Expected behavior:

File picker works when clicking <c-f>.

## Actual behavior:

Package throws error:

```
Failed to run `config` for jfind.nvim                                                                                                                                                                                                                                                         
...ejf/.local/share/nvim/lazy/jfind.nvim/lua/jfind/init.lua:10: attempt to concatenate local 'CACHE' (a userdata value)
# stacktrace:
  - /jfind.nvim/lua/jfind/init.lua:10
```

## Fix:

After debugging, on my machine (running Arch) the value of `vim.fn.getenv("XDG_CACHE_HOME")` is `vim.NIL`. I'm not fully sure what this is used for, but a check for the nil value next to the empty string check fixed the issue for me and the package now works as expected (blazingly fast).

### P.S.

I would love it if you could add some sort of version/tag/branch so I can lock the package in my lazy.lock so new bugs pushed to master don't break my environment <3 Package looking great so far.