### PR TITLE
add findFlags config to jfind.findFiles

### DIFF
--- a/lua/jfind/init.lua
+++ b/lua/jfind/init.lua
@@ -256,6 +256,7 @@ local function findFile(opts)
     if opts.hidden == nil then opts.hidden = true end
     if opts.history == nil then opts.history = "~/.cache/jfind_find_file_history" end
     if opts.history == false then opts.history = nil end
+    if type(opts.findFlags) ~= "table" then opts.findFlags = {} end
     local formatPaths = ternary(opts.formatPaths, "true", "false")
     local hidden = ternary(opts.hidden, "true", "false")
 
@@ -270,9 +271,14 @@ local function findFile(opts)
         preview = opts.preview
     end
 
+    local args = {formatPaths, hidden}
+    if (opts.findFlags ~= nil) then
+        table.insert(args, table.concat(opts.findFlags, " "))
+    end
+
     jfind({
         script = JFIND_FILE_SCRIPT,
-        args = {formatPaths, hidden},
+        args = args,
         hints = opts.formatPaths,
         selectAll = opts.selectAll,
         preview = preview,
@@ -281,6 +287,7 @@ local function findFile(opts)
         queryPosition = opts.queryPosition,
         history = opts.history,
         callback = opts.callback,
+        flags = opts.findFlags
     })
 end
 

--- a/scripts/jfind-file.sh
+++ b/scripts/jfind-file.sh
@@ -17,13 +17,15 @@ list_files() {
         exclude=$(cat "$EXCLUDES" 2>/dev/null \
             | sed "s/'/'\"'\"'/g" | awk "{printf \" -E '%s'\", "'$0}')
         [ "$1" = "true" ] && hiddenFlag="--hidden"
-        eval "$fd_command $hiddenFlag --type f $exclude"
+        flags=$2
+        eval "$fd_command $hiddenFlag --type f $exclude $flags"
     else
         exclude=$(cat "$EXCLUDES" 2>/dev/null \
             | sed "s/'/'\"'\"'/g" \
             | awk "{printf \" ! -path '*/%s/*' ! -iname '%s'\", "'$0, $0}')
         [ "$1" != "true" ] && hiddenFlag="-not -path '*/.*'"
-        eval "find '.' $hiddenFlag -type f $exclude"
+        flags=$2
+        eval "find '.' $hiddenFlag -type f $exclude $flags"
     fi
 }
 
@@ -39,8 +41,8 @@ format_files() {
 }
 
 if [ "$1" = "true" ]; then
-    list_files "$2" | format_files
+    list_files "$2" "$3" | format_files
 else
-    list_files "$2"
+    list_files "$2" "$3"
 fi
 


### PR DESCRIPTION
Hi @jake-stewart,

Thanks so much for the help with #17! It took me quite a while longer than expected but between the crazy weather in europe, changing jobs and my laptop dying I didn’t have much time to dedicate to this 🥲. I finally found a bit of time though and looked over the changes and my own branch. 

Your changes for liveGrep are exactly what I wanted, but I could also use some similar functionality in findFiles which is what this MR is for.

I named the config findFlags, although there are different possible find commands but I’m not sure if having separate configs  is something you’d want, though it might be nice to add them for consistency and if users want to have a preset config for findFiles and want the ability to change the find command quickly/easily, without losing their config. I do believe that find and fdfind have different APIs so separating these configs might make sense. Let me know if that’s something you’d prefer and I can change it.

Let me know if there’s anything about the implementation you don’t like, or if you think I’m on the right track 🙂 

Best regards,
Andrej